### PR TITLE
Improve how screenshots are displayed

### DIFF
--- a/src/app/qml/AppPage.qml
+++ b/src/app/qml/AppPage.qml
@@ -55,12 +55,18 @@ FluidControls.Page {
 
         property alias source: screenshot.source
 
-        width: Math.min(appPage.width * 0.9, screenshot.sourceSize.width)
-        height: Math.min(appPage.height * 0.9, screenshot.sourceSize.height)
+        anchors.centerIn: parent
+
+        width: parent.width * 0.9
+        height: parent.height * 0.9
 
         Image {
             id: screenshot
+
             anchors.fill: parent
+            sourceSize.width: screenshot.sourceSize.width
+            sourceSize.height: screenshot.sourceSize.height
+            fillMode: Image.PreserveAspectFit
 
             MouseArea {
                 anchors.fill: parent

--- a/src/app/qml/app/Screenshots.qml
+++ b/src/app/qml/app/Screenshots.qml
@@ -8,35 +8,40 @@ import QtQuick.Layouts 1.2
 import Fluid.Controls 1.0 as FluidControls
 import Liri.AppCenter 1.0 as AppCenter
 
-ListView {
-    ScrollBar.horizontal: ScrollBar {}
+ScrollView {
     Layout.fillWidth: true
-    Layout.preferredHeight: 120
+    Layout.preferredHeight: screenshotsModel.maximumThumbnailSize.height / 2
 
     clip: true
-    orientation: ListView.Horizontal
-    spacing: FluidControls.Units.smallSpacing
-    visible: count > 0
-    model: AppCenter.ScreenshotsModel {
-        app: appPage.app
-    }
-    delegate: Image {
-        id: thumbnail
 
-        source: model.thumbnailUrl
+    ListView {
+        orientation: ListView.Horizontal
+        spacing: FluidControls.Units.smallSpacing
+        visible: count > 0
+        model: AppCenter.ScreenshotsModel {
+            id: screenshotsModel
 
-        width: height * (model.thumbnailSize.width / model.thumbnailSize.height)
-        height: ListView.view.height
-        visible: status !== Image.Error
-
-        BusyIndicator {
-            anchors.centerIn: parent
-            visible: thumbnail.status == Image.Loading
+            app: appPage.app
         }
+        delegate: Image {
+            id: thumbnail
 
-        FluidControls.Ripple {
-            anchors.fill: parent
-            onClicked: screenshotOverlay.show(model.screenshotUrl)
+            source: model.thumbnailUrl
+            sourceSize.width: model.thumbnailSize.width / 2
+            sourceSize.height: model.thumbnailSize.height / 2
+            width: model.thumbnailSize.width / 2
+            height: model.thumbnailSize.height / 2
+            visible: status !== Image.Error
+
+            BusyIndicator {
+                anchors.centerIn: parent
+                visible: thumbnail.status == Image.Loading
+            }
+
+            FluidControls.Ripple {
+                anchors.fill: parent
+                onClicked: screenshotOverlay.show(model.screenshotUrl)
+            }
         }
     }
 }

--- a/src/framework/screenshotsmodel.cpp
+++ b/src/framework/screenshotsmodel.cpp
@@ -5,6 +5,8 @@
 #include "screenshotsmodel.h"
 #include "screenshotsmodel_p.h"
 
+#include <QDebug>
+
 namespace Liri {
 
 namespace AppCenter {
@@ -88,6 +90,24 @@ void ScreenshotsModel::setApp(SoftwareResource *app)
     d->screenshots = d->app->screenshots();
     Q_EMIT appChanged();
     endResetModel();
+}
+
+QSize ScreenshotsModel::maximumThumbnailSize() const
+{
+    Q_D(const ScreenshotsModel);
+
+    QSize lastSize, maxSize;
+
+    for (const auto &thumbnail : qAsConst(d->thumbnails)) {
+        if (!lastSize.isValid() && thumbnail.size().width() > lastSize.width() && thumbnail.size().height() > lastSize.height()) {
+            maxSize = thumbnail.size();
+            break;
+        }
+
+        lastSize = thumbnail.size();
+    }
+
+    return maxSize;
 }
 
 QUrl ScreenshotsModel::thumbnailUrlAt(int index) const

--- a/src/framework/screenshotsmodel.h
+++ b/src/framework/screenshotsmodel.h
@@ -20,6 +20,7 @@ class LIRIAPPCENTER_EXPORT ScreenshotsModel : public QAbstractListModel
 {
     Q_OBJECT
     Q_PROPERTY(SoftwareResource *app READ app WRITE setApp NOTIFY appChanged)
+    Q_PROPERTY(QSize maximumThumbnailSize READ maximumThumbnailSize NOTIFY appChanged)
     Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
     Q_DECLARE_PRIVATE(ScreenshotsModel)
     Q_DISABLE_COPY(ScreenshotsModel)
@@ -40,6 +41,8 @@ public:
 
     SoftwareResource *app() const;
     void setApp(SoftwareResource *app);
+
+    QSize maximumThumbnailSize() const;
 
     Q_INVOKABLE QUrl thumbnailUrlAt(int index) const;
     Q_INVOKABLE QUrl screenshotUrlAt(int index) const;


### PR DESCRIPTION
Resize the thumbnails view to fit the biggest thumbnail and resize the
screenshot to keep the aspect ratio.